### PR TITLE
Bump heck 0.4 -> 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 proc-macro2 = "1.0.34"
 quote = "1.0.10"
 toml = "0.8.10"
-heck = "0.4.0"
+heck = "0.5.0"
 
 [dependencies.serde]
 version = "1.0.133"


### PR DESCRIPTION
CHANGELOG says that the only breaking change is the removal of the `unicode` feature, as it is now default, which this crate wasn't using anyway.