### PR TITLE
Add support for `#[required]` fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
 **/Cargo.lock
-**/target/*
+**/target

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Rough ideas:
 * Crates can declare variables that can be overridden
     * Anything const, e.g. usize, strings, etc.
 * (Only) The "root crate" can override these variables by including a `cfg.toml` file
+* Variables can either have default values (`#[default(...)]`) or fail at compile-time if not configured (`#[required]`)
 
 ## Config file
 
@@ -18,7 +19,7 @@ buffer_size = 4096
 greeting = "Guten Tag!"
 ```
 
-## In the library
+### In the library
 
 ```rust
 // lib-one
@@ -34,38 +35,61 @@ pub struct Config {
     #[default("hello")]
     greeting: &'static str,
 }
-
 ```
 
-## Look at what we get!
+### Look at what we get!
 
-```shell
+```console
 # Print the "buffer_size" value from the `lib-one` crate.
 # Since it has no cfg.toml, we just get the default value.
 $ cd pkg-example/lib-one
-$ cargo run
-    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
-     Running `target/debug/lib-one`
+$ cargo run --quiet
 32
 
 # Print the "greeting" value from the `lib-two` crate.
 # Since it has no cfg.toml, we just get the default value.
 $ cd ../lib-two
-$ cargo run
-   Compiling lib-two v0.1.0 (/home/james/personal/toml-cfg/pkg-example/lib-two)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.32s
-     Running `target/debug/lib-two`
+$ cargo run --quiet
 hello
 
 # Print the "buffer_size" value from `lib-one`, and "greeting"
 # from `lib-two`. Since we HAVE defined a `cfg.toml` file, the
 # values defined there are used instead.
 $ cd ../application
-$ cargo run
-   Compiling lib-two v0.1.0 (/home/james/personal/toml-cfg/pkg-example/lib-two)
-   Compiling application v0.1.0 (/home/james/personal/toml-cfg/pkg-example/application)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
-     Running `target/debug/application`
+$ cargo run --quiet
 4096
 Guten Tag!
+```
+
+### `#[required]` fields
+
+```rust
+#[toml_cfg::toml_config]
+pub struct Config {
+    #[required]
+    wifi_ssid: &'static str,
+    // If empty assume unencrypted.
+    #[default("")]
+    wifi_passkey: &'static str,
+}
+```
+
+```toml
+[failing-config]
+# Oops, I forgot to set `wifi_ssid`.
+wifi_passkey = "my_password"
+```
+
+```console
+$ cd ../failing-config
+$ cargo build --quiet
+error: custom attribute panicked
+ --> src/lib.rs:3:1
+  |
+3 | #[toml_cfg::toml_config]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Field `wifi_ssid`: required but no value was provided in the config file.
+
+error: could not compile `failing-config` (lib) due to 1 previous error
 ```

--- a/pkg-example/failing-config/Cargo.toml
+++ b/pkg-example/failing-config/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "failing-config"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies.toml-cfg]
+path = "../../"

--- a/pkg-example/failing-config/cfg.toml
+++ b/pkg-example/failing-config/cfg.toml
@@ -1,0 +1,3 @@
+[failing-config]
+# Oops, I forgot to set `wifi_ssid`.
+wifi_passkey = "my_password"

--- a/pkg-example/failing-config/src/lib.rs
+++ b/pkg-example/failing-config/src/lib.rs
@@ -1,0 +1,10 @@
+#![no_std]
+
+#[toml_cfg::toml_config]
+pub struct Config {
+    #[required]
+    wifi_ssid: &'static str,
+    // If empty assume unencrypted.
+    #[default("")]
+    wifi_passkey: &'static str,
+}


### PR DESCRIPTION
Hey! Love the library, I use it a lot for embedding configuration and credentials into embedded devices.

The `failing-config` example I've added basically describes the use-case that motivated this: I wanted a config that requires some fields (e.g. `wifi_ssid`) to be set but doesn't necessarily need other fields (e.g. `wifi_passkey`, ...). I could provide defaults for everything then check for non-default values at runtime, but that's verbose and negates the awesomeness of this crate: being able to control the config at compile-time.

```rust
#[toml_cfg::toml_config]
pub struct Config {
    #[required]  // this is new
    wifi_ssid: &'static str,
    #[default("")]
    wifi_passkey: &'static str,
}
```

```toml
[failing-config]
# Oops, I forgot to set `wifi_ssid`.
wifi_passkey = "my_password"
```

```console
$ cd ../failing-config
$ cargo build --quiet
error: custom attribute panicked
 --> src/lib.rs:3:1
  |
3 | #[toml_cfg::toml_config]
  | ^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: Field `wifi_ssid`: required but no value was provided in the config file.

error: could not compile `failing-config` (lib) due to 1 previous error
```

This is backwards compatible except for error messages: `#[default(...)]` behaves identically, users have to add `#[required]` to see any new behaviour.

First two commits are just housekeeping, 3rd commit is implementation+documentation.