### PR TITLE
resolve CARGO_BIN_NAME env variable at compile time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ pub fn toml_config(_attr: TokenStream, item: TokenStream) -> TokenStream {
 fn load_crate_cfg(path: &Path) -> Option<Defn> {
     let contents = std::fs::read_to_string(&path).ok()?;
     let parsed = toml::from_str::<Config>(&contents).ok()?;
-    let name = env::var("CARGO_PKG_NAME").ok()?;
+    let name = env!("CARGO_PKG_NAME");
     parsed.crates.get(&name).cloned()
 }
 


### PR DESCRIPTION
this adds support for environments in which environment variables are not present at runtime, e.g esp32 projects which are compiled using embuild

since CARGO_BIN_NAME doesn't change between compile- and runtime, unless overriden (which is a questionable scenario), this is a valid replacement.